### PR TITLE
Update dependencies and require Node.js 8

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{package.json,*.yml}]
+[*.yml]
 indent_style = space
 indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-* text=auto
-*.js text eol=lf
+* text=auto eol=lf

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - '6'
-  - '4'
+  - '12'
+  - '10'
+  - '8'

--- a/json.js
+++ b/json.js
@@ -7,8 +7,8 @@ module.exports = (module, filename) => {
 
 	try {
 		module.exports = JSON.parse(stripBom(content));
-	} catch (err) {
-		err.message = `${filename}: ${err.message}`;
-		throw err;
+	} catch (error) {
+		error.message = `${filename}: ${error.message}`;
+		throw error;
 	}
 };

--- a/package.json
+++ b/package.json
@@ -1,42 +1,42 @@
 {
-  "name": "default-require-extensions",
-  "version": "2.0.0",
-  "description": "Node's default require extensions as a separate module",
-  "license": "MIT",
-  "repository": "avajs/default-require-extensions",
-  "author": {
-    "name": "James Talmage",
-    "email": "james@talmage.io",
-    "url": "github.com/jamestalmage"
-  },
-  "engines": {
-    "node": ">=8"
-  },
-  "scripts": {
-    "test": "xo && nyc ava"
-  },
-  "main": "js.js",
-  "files": [
-    "js.js",
-    "json.js"
-  ],
-  "keywords": [
-    "require",
-    "extension",
-    "default",
-    "node"
-  ],
-  "dependencies": {
-    "strip-bom": "^4.0.0"
-  },
-  "devDependencies": {
-    "ava": "^2.3.0",
-    "nyc": "^14.1.1",
-    "xo": "^0.24.0"
-  },
-  "nyc": {
-    "exclude": [
-      "fixture"
-    ]
-  }
+	"name": "default-require-extensions",
+	"version": "2.0.0",
+	"description": "Node's default require extensions as a separate module",
+	"license": "MIT",
+	"repository": "avajs/default-require-extensions",
+	"author": {
+		"name": "James Talmage",
+		"email": "james@talmage.io",
+		"url": "github.com/jamestalmage"
+	},
+	"engines": {
+		"node": ">=8"
+	},
+	"scripts": {
+		"test": "xo && nyc ava"
+	},
+	"main": "js.js",
+	"files": [
+		"js.js",
+		"json.js"
+	],
+	"keywords": [
+		"require",
+		"extension",
+		"default",
+		"node"
+	],
+	"dependencies": {
+		"strip-bom": "^4.0.0"
+	},
+	"devDependencies": {
+		"ava": "^2.3.0",
+		"nyc": "^14.1.1",
+		"xo": "^0.24.0"
+	},
+	"nyc": {
+		"exclude": [
+			"fixture"
+		]
+	}
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "github.com/jamestalmage"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "scripts": {
     "test": "xo && nyc ava"
@@ -27,12 +27,12 @@
     "node"
   ],
   "dependencies": {
-    "strip-bom": "^3.0.0"
+    "strip-bom": "^4.0.0"
   },
   "devDependencies": {
-    "ava": "^0.18.2",
-    "nyc": "^10.1.2",
-    "xo": "^0.18.1"
+    "ava": "^2.3.0",
+    "nyc": "^14.1.1",
+    "xo": "^0.24.0"
   },
   "nyc": {
     "exclude": [

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ By the time your extension is loaded, the default extension may have already bee
 ## Install
 
 ```
-$ npm install --save default-require-extensions
+$ npm install default-require-extensions
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-duplicates */
+/* eslint-disable import/no-duplicates, node/no-deprecated-api */
 import test from 'ava';
 import js from './js';
 import json from './json';
@@ -9,7 +9,7 @@ require.extensions['.json'] = json;
 
 const _require = require;
 
-test(t => {
+test('basic', t => {
 	t.is(def, js);
 	t.is(require('./fixture/foo.js'), 'foo');
 	t.is(require('./fixture/foo.json'), 'foo');


### PR DESCRIPTION
The semver-major of strip-bom only bumps the required Node.js to >=8.  The second commit meta tweaks is based on stuff found in other repositories maintained by @sindresorhus.